### PR TITLE
Fixed github icon in dark mode

### DIFF
--- a/assets/javascript/app.js
+++ b/assets/javascript/app.js
@@ -1,10 +1,18 @@
-$(".change").on("click",function(){
-  if($("body").hasClass("dark")) {
+$(".change").on("click", function () {
+  const icons = $(".icon-link-github")
+
+  if ($("body").hasClass("dark")) {
     $("body").removeClass("dark");
     $(".change").text("Dark");
+    for (let i = 0; i < icons.length; i++) {
+      icons[i].style.filter = ''
+    }
   } else {
     $("body").addClass("dark");
     $(".change").text("Light");
+    for (let i = 0; i < icons.length; i++) {
+      icons[i].style.filter = 'invert(100%)'
+    }
   }
 });
 


### PR DESCRIPTION
Fixed dark mode issue.
Preview:

![image](https://user-images.githubusercontent.com/56617785/195012320-ae33e3a8-3952-4efa-8630-146d69c02350.png)
